### PR TITLE
Use rpmbuild instead of mock for builders

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: f${{ matrix.branch }}
+          ref: ${{ startsWith(matrix.branch, 'el') && '' || 'f' }}${{ matrix.branch }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ startsWith(matrix.branch, 'el') && '' || 'f' }}${{ matrix.branch }}
+          ref: ${{ !startsWith(matrix.branch, 'el') && 'f' }}${{ matrix.branch }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ !startsWith(matrix.branch, 'el') && 'f' }}${{ matrix.branch }}
+          ref: ${{ !startsWith(matrix.branch, 'el') && 'f' || '' }}${{ matrix.branch }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: ARM64
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ RUN curl https://cli.github.com/packages/rpm/gh-cli.repo -o /etc/yum.repos.d/gh-
 
 RUN dnf5 -y --setopt=install_weak_deps=False install subatomic-cli anda rpm-build rpmlint git-core git-lfs wget less fuse-overlayfs sudo gh
 
-RUN dnf5 clean all
+# Hack to fix %dist
+RUN sed -i 's/.fc%{fedora}/.fcrawhide/g' /usr/lib/rpm/macros.d/macros.dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM registry.fedoraproject.org/fedora-minimal:rawhide
 
+COPY dnf.conf /etc/dnf/dnf.conf
+
 RUN dnf5 update -y --setopt=install_weak_deps=False
 
 RUN curl https://github.com/terrapkg/subatomic-repos/raw/main/terra.repo -Lo /etc/yum.repos.d/terra.repo
 RUN curl https://cli.github.com/packages/rpm/gh-cli.repo -o /etc/yum.repos.d/gh-cli.repo
 
-RUN dnf5 -y --setopt=install_weak_deps=False install subatomic-cli anda rpm-build rpmlint git-core git-lfs wget less fuse-overlayfs sudo gh
+RUN dnf5 -y --setopt=install_weak_deps=False install subatomic-cli anda rpm-build rpmlint git-core git-lfs wget less fuse-overlayfs sudo gh dnf5-plugins createrepo_c
 
 # Hack to fix %dist
 RUN sed -i 's/.fc%{fedora}/.fcrawhide/g' /usr/lib/rpm/macros.d/macros.dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,9 @@ FROM registry.fedoraproject.org/fedora-minimal:rawhide
 
 RUN dnf5 update -y --setopt=install_weak_deps=False
 
-RUN dnf5 install -y --setopt=install_weak_deps=False dnf5-plugins
-RUN dnf5 config-manager addrepo --from-repofile='https://github.com/terrapkg/subatomic-repos/raw/main/terra.repo'
-RUN dnf5 config-manager addrepo --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo
+RUN curl https://github.com/terrapkg/subatomic-repos/raw/main/terra.repo -o /etc/yum.repos.d/terra.repo
+RUN curl https://cli.github.com/packages/rpm/gh-cli.repo -o /etc/yum.repos.d/gh-cli.repo
 
-RUN dnf5 -y --setopt=install_weak_deps=False install terra-mock-configs subatomic-cli anda mock rpm-build mock-scm rpmlint git-core git-lfs curl wget less podman fuse-overlayfs sudo gh
+RUN dnf5 -y --setopt=install_weak_deps=False install subatomic-cli anda rpm-build rpmlint git-core git-lfs wget less fuse-overlayfs sudo gh
 
 RUN dnf5 clean all

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@ FROM registry.fedoraproject.org/fedora-minimal:rawhide
 
 COPY dnf.conf /etc/dnf/dnf.conf
 
-RUN dnf5 update -y --setopt=install_weak_deps=False
-
-RUN curl https://github.com/terrapkg/subatomic-repos/raw/main/terra.repo -Lo /etc/yum.repos.d/terra.repo
 RUN curl https://cli.github.com/packages/rpm/gh-cli.repo -o /etc/yum.repos.d/gh-cli.repo
 
 RUN dnf5 in -y --setopt=install_weak_deps=False --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' --setopt='terra.gpgkey=https://repos.fyralabs.com/terra$releasever/key.asc' terra-{release{,-extra},mock-configs} subatomic-cli anda mock rpm-build mock-scm rpmlint git-{core,lfs} wget less podman fuse-overlayfs sudo gh dnf5-plugins createrepo_c

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.fedoraproject.org/fedora-minimal:rawhide
 
 RUN dnf5 update -y --setopt=install_weak_deps=False
 
-RUN curl https://github.com/terrapkg/subatomic-repos/raw/main/terra.repo -o /etc/yum.repos.d/terra.repo
+RUN curl https://github.com/terrapkg/subatomic-repos/raw/main/terra.repo -Lo /etc/yum.repos.d/terra.repo
 RUN curl https://cli.github.com/packages/rpm/gh-cli.repo -o /etc/yum.repos.d/gh-cli.repo
 
 RUN dnf5 -y --setopt=install_weak_deps=False install subatomic-cli anda rpm-build rpmlint git-core git-lfs wget less fuse-overlayfs sudo gh

--- a/dnf.conf
+++ b/dnf.conf
@@ -1,0 +1,55 @@
+[main]
+gpgcheck=True
+reposdir=/dev/null
+keepcache=1
+retries=20
+gpgcheck=1
+install_weak_deps=0
+metadata_expire=0
+best=1
+tsflags=nodocs
+max_parallel_downloads=20
+
+[terra]
+name=Terra $releasever
+baseurl=https://repos.fyralabs.com/terra$releasever
+type=rpm
+skip_if_unavailable=True
+repo_gpgcheck=1
+gpgkey=https://repos.fyralabs.com/terra$releasever/key.asc
+enabled=1
+enabled_metadata=1
+metadata_expire=0
+
+# Only used for multilib builds, pulls straight from fedora koji
+# Use /rawhide/latest instead of /f{{ releasever }}-build/latest for rawhide
+[local-build]
+name=local
+baseurl=https://kojipkgs.fedoraproject.org/repos/f$releasever-build/latest/$basearch/
+cost=2000
+# enabled only if not mirrored, and not rawhide
+enabled=0
+skip_if_unavailable=False
+
+[local-rawhide-build]
+name=local-rawhide
+baseurl=https://kojipkgs.fedoraproject.org/repos/rawhide/latest/$basearch/
+cost=2000
+# enabled only if not mirrored, and rawhide
+enabled=0
+skip_if_unavailable=False
+
+[fedora]
+name=fedora
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-{{ releasever }}-primary
+gpgcheck=1
+skip_if_unavailable=False
+exclude=fedora-release*
+
+[updates]
+name=updates
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-{{ releasever }}-primary
+gpgcheck=1
+skip_if_unavailable=False

--- a/dnf.conf
+++ b/dnf.conf
@@ -10,17 +10,6 @@ best=1
 tsflags=nodocs
 max_parallel_downloads=20
 
-[terra]
-name=Terra $releasever
-baseurl=https://repos.fyralabs.com/terra$releasever
-type=rpm
-skip_if_unavailable=True
-repo_gpgcheck=1
-gpgkey=https://repos.fyralabs.com/terra$releasever/key.asc
-enabled=1
-enabled_metadata=1
-metadata_expire=0
-
 # Only used for multilib builds, pulls straight from fedora koji
 # Use /rawhide/latest instead of /f{{ releasever }}-build/latest for rawhide
 [local-build]
@@ -42,7 +31,7 @@ skip_if_unavailable=False
 [fedora]
 name=fedora
 metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
-gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-{{ releasever }}-primary
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
 gpgcheck=1
 skip_if_unavailable=False
 exclude=fedora-release*
@@ -50,6 +39,7 @@ exclude=fedora-release*
 [updates]
 name=updates
 metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
-gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-{{ releasever }}-primary
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
 gpgcheck=1
+repo_gpgcheck=0
 skip_if_unavailable=False


### PR DESCRIPTION
Using mock in builders doesn't make sense since that's having a container inside another container, so might as well use `rpmbuild` directly.

This PR adds things that can enable the use of `rpmbuild`.