### PR TITLE
Swap EL10 builder to Alma over CentOS

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: f${{ matrix.branch }}
+          ref: ${{ !startsWith(matrix.branch, "el") && "f" }}${{ matrix.branch }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,7 +18,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        branch: ["39", "40", "41", "rawhide"]
+        branch: ["39", "40", "41", "rawhide", "el10"]
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: ARM64
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -22,15 +22,15 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ !startsWith(matrix.branch, 'el') && 'f' }}${{ matrix.branch }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v2.2.1
+        uses: docker/setup-buildx-action@v3.7.1
 
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
@@ -46,4 +46,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:f${{ matrix.branch }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ !startsWith(matrix.branch, 'el') && 'f' }}${{ matrix.branch }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ !startsWith(matrix.branch, "el") && "f" }}${{ matrix.branch }}
+          ref: ${{ !startsWith(matrix.branch, 'el') && 'f' }}${{ matrix.branch }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ !startsWith(matrix.branch, 'el') && 'f' }}${{ matrix.branch }}
+          ref: ${{ !startsWith(matrix.branch, 'el') && 'f' || '' }}${{ matrix.branch }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -46,4 +46,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ !startsWith(matrix.branch, 'el') && 'f' }}${{ matrix.branch }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ !startsWith(matrix.branch, 'el') && 'f' || '' }}${{ matrix.branch }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN rpm -i ./*.rpm && \
     sed -Ei '/^metalink/ s/^/#/' /etc/yum.repos.d/epel.repo && \
     sed -Ei '/\[crb\]/,/^$/ s@^enabled=0$@enabled=1@' /etc/yum.repos.d/centos.repo
 
-RUN dnf in -y --setopt=install_weak_deps=False --repofrompath 'terra,https://repos.fyralabs.com/terrael$releasever' --setopt='terra.gpgkey=https://repos.fyralabs.com/terrael$releasever/key.asc' terra-{release,mock-configs} anda-srpm-macros subatomic-cli anda rpm-build git-lfs wget less podman fuse-overlayfs gh mold util-linux
+RUN dnf in -y --setopt=install_weak_deps=False --repofrompath 'terra,https://repos.fyralabs.com/terrael$releasever' --setopt='terra.gpgkey=https://repos.fyralabs.com/terrael$releasever/key.asc' terra-{release,mock-configs} anda-srpm-macros subatomic-cli anda rpm-build git-lfs wget less podman fuse-overlayfs gh util-linux bash bzip2 centos-stream-release coreutils cpio diffutils epel-rpm-macros findutils gawk glibc-minimal-langpack grep gzip info patch redhat-rpm-config sed tar unzip which xz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM registry.fedoraproject.org/fedora-minimal:rawhide
+FROM quay.io/centos/centos:stream10-development
 
-RUN echo 'max_parallel_downloads=20' >> /etc/dnf/dnf.conf
-RUN dnf5 update -y --setopt=install_weak_deps=False
+RUN sed -i 's@^enabled=0@enabled=1@' /etc/yum.repos.d/almalinux-crb.repo &\
+    curl https://dl.fedoraproject.org/pub/epel/10/Everything/x86_64/os/Packages/e/epel-release-10-1.el10_0.noarch.rpm -o epel-release-latest-10.noarch.rpm &\
+    curl https://cli.github.com/packages/rpm/gh-cli.repo -o /etc/yum.repos.d/gh-cli.repo &\
+    echo 'max_parallel_downloads=20' >> /etc/dnf/dnf.conf &\
+    wait
 
-RUN dnf5 install -y --setopt=install_weak_deps=False dnf5-plugins
-RUN dnf5 config-manager addrepo --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo
+RUN rpm -i ./*.rpm && \
+    sed -Ei "s@^#baseurl=.+@baseurl=https://dl.fedoraproject.org/pub/epel/\$releasever_major\${releasever_minor:+.\$releasever_minor}/Everything/\$basearch/os/@" /etc/yum.repos.d/epel.repo && \
+    sed -Ei '/^metalink/ s/^/#/' /etc/yum.repos.d/epel.repo
 
-RUN dnf5 in -y --setopt=install_weak_deps=False --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' --setopt='terra.gpgkey=https://repos.fyralabs.com/terra$releasever/key.asc' terra-{release,mock-configs} subatomic-cli anda mock rpm-build mock-scm rpmlint git-lfs wget less podman fuse-overlayfs sudo gh
+RUN dnf in -y --setopt=install_weak_deps=False --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' --setopt='terra.gpgkey=https://repos.fyralabs.com/terra$releasever/key.asc' terra-{release,mock-configs} subatomic-cli anda mock rpm-build mock-scm rpmlint git-lfs wget less podman fuse-overlayfs sudo gh
 
-RUN dnf5 clean all
+RUN dnf clean all

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ RUN rpm -i ./*.rpm && \
     sed -Ei '/^metalink/ s/^/#/' /etc/yum.repos.d/epel.repo && \
     sed -Ei '/\[crb\]/,/^$/ s@^enabled=0$@enabled=1@' /etc/yum.repos.d/centos.repo
 
-RUN dnf in -y --setopt=install_weak_deps=False --repofrompath 'terra,https://repos.fyralabs.com/terrael$releasever' --setopt='terra.gpgkey=https://repos.fyralabs.com/terrael$releasever/key.asc' terra-{release,mock-configs} subatomic-cli anda mock rpm-build mock-scm git-lfs wget less podman fuse-overlayfs sudo gh
+RUN dnf in -y --setopt=install_weak_deps=False --repofrompath 'terra,https://repos.fyralabs.com/terrael$releasever' --setopt='terra.gpgkey=https://repos.fyralabs.com/terrael$releasever/key.asc' terra-{release,mock-configs} subatomic-cli anda mock rpm-build mock-scm git-lfs wget less podman fuse-overlayfs sudo gh script
 
 RUN dnf clean all

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN rpm -i ./*.rpm && \
     sed -Ei '/^metalink/ s/^/#/' /etc/yum.repos.d/epel.repo && \
     sed -Ei '/\[crb\]/,/^$/ s@^enabled=0$@enabled=1@' /etc/yum.repos.d/centos.repo
 
-RUN dnf in -y --setopt=install_weak_deps=False --repofrompath 'terra,https://repos.fyralabs.com/terrael$releasever' --setopt='terra.gpgkey=https://repos.fyralabs.com/terrael$releasever/key.asc' terra-{release,mock-configs} anda-srpm-macros subatomic-cli anda rpm-build git-lfs wget less podman fuse-overlayfs gh util-linux bash bzip2 centos-stream-release coreutils cpio diffutils epel-rpm-macros findutils gawk glibc-minimal-langpack grep gzip info patch redhat-rpm-config sed tar unzip which xz
+RUN dnf in -y --setopt=install_weak_deps=False --repofrompath 'terra,https://repos.fyralabs.com/terrael$releasever' --setopt='terra.gpgkey=https://repos.fyralabs.com/terrael$releasever/key.asc' terra-{release,mock-configs} anda-srpm-macros subatomic-cli anda rpm-build git-lfs wget less podman fuse-overlayfs gh util-linux bash bzip2 centos-stream-release cpio diffutils epel-rpm-macros findutils gawk glibc-minimal-langpack grep gzip info patch redhat-rpm-config sed tar unzip which xz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/centos/centos:stream10-development
 
 #RUN sed -i 's@^enabled=0@enabled=1@' /etc/yum.repos.d/almalinux-crb.repo &\
-RUN curl https://dl.fedoraproject.org/pub/epel/10/Everything/$(rpm -E '%_arch')/Packages/e/epel-release-10-2.el10_0.noarch.rpm -o epel-release-latest-10.noarch.rpm &\
+RUN curl https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm -o epel-release-latest-10.noarch.rpm &\
     curl https://cli.github.com/packages/rpm/gh-cli.repo -o /etc/yum.repos.d/gh-cli.repo &\
     echo 'max_parallel_downloads=20' >> /etc/dnf/dnf.conf &\
     wait

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream10-development
+FROM quay.io/almalinuxorg/almalinux:10-kitten
 
 #RUN sed -i 's@^enabled=0@enabled=1@' /etc/yum.repos.d/almalinux-crb.repo &\
 RUN curl https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm -o epel-release-latest-10.noarch.rpm &\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream10-development-minimal
+FROM quay.io/centos/centos:stream10-development
 
 #RUN sed -i 's@^enabled=0@enabled=1@' /etc/yum.repos.d/almalinux-crb.repo &\
 RUN curl https://dl.fedoraproject.org/pub/epel/10/Everything/$(rpm -E '%_arch')/Packages/e/epel-release-10-2.el10_0.noarch.rpm -o epel-release-latest-10.noarch.rpm &\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
-FROM quay.io/centos/centos:stream10-development
+FROM quay.io/centos/centos:stream10-development-minimal
 
-RUN sed -i 's@^enabled=0@enabled=1@' /etc/yum.repos.d/almalinux-crb.repo &\
-    curl https://dl.fedoraproject.org/pub/epel/10/Everything/x86_64/os/Packages/e/epel-release-10-1.el10_0.noarch.rpm -o epel-release-latest-10.noarch.rpm &\
+#RUN sed -i 's@^enabled=0@enabled=1@' /etc/yum.repos.d/almalinux-crb.repo &\
+RUN curl https://dl.fedoraproject.org/pub/epel/10/Everything/$(rpm -E '%_arch')/Packages/e/epel-release-10-2.el10_0.noarch.rpm -o epel-release-latest-10.noarch.rpm &\
     curl https://cli.github.com/packages/rpm/gh-cli.repo -o /etc/yum.repos.d/gh-cli.repo &\
     echo 'max_parallel_downloads=20' >> /etc/dnf/dnf.conf &\
     wait
 
 RUN rpm -i ./*.rpm && \
-    sed -Ei "s@^#baseurl=.+@baseurl=https://dl.fedoraproject.org/pub/epel/\$releasever_major\${releasever_minor:+.\$releasever_minor}/Everything/\$basearch/os/@" /etc/yum.repos.d/epel.repo && \
-    sed -Ei '/^metalink/ s/^/#/' /etc/yum.repos.d/epel.repo
+    sed -Ei "s@^#baseurl=.+@baseurl=https://dl.fedoraproject.org/pub/epel/\$releasever_major\${releasever_minor:+.\$releasever_minor}/Everything/\$basearch/@" /etc/yum.repos.d/epel.repo && \
+    sed -Ei '/^metalink/ s/^/#/' /etc/yum.repos.d/epel.repo && \
+    sed -Ei '/\[crb\]/,/^$/ s@^enabled=0$@enabled=1@' /etc/yum.repos.d/centos.repo
 
-RUN dnf in -y --setopt=install_weak_deps=False --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' --setopt='terra.gpgkey=https://repos.fyralabs.com/terra$releasever/key.asc' terra-{release,mock-configs} subatomic-cli anda mock rpm-build mock-scm rpmlint git-lfs wget less podman fuse-overlayfs sudo gh
+RUN dnf in -y --setopt=install_weak_deps=False --repofrompath 'terra,https://repos.fyralabs.com/terrael$releasever' --setopt='terra.gpgkey=https://repos.fyralabs.com/terrael$releasever/key.asc' terra-{release,mock-configs} subatomic-cli anda mock rpm-build mock-scm git-lfs wget less podman fuse-overlayfs sudo gh
 
 RUN dnf clean all

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,4 @@ RUN rpm -i ./*.rpm && \
     sed -Ei '/^metalink/ s/^/#/' /etc/yum.repos.d/epel.repo && \
     sed -Ei '/\[crb\]/,/^$/ s@^enabled=0$@enabled=1@' /etc/yum.repos.d/centos.repo
 
-RUN dnf in -y --setopt=install_weak_deps=False --repofrompath 'terra,https://repos.fyralabs.com/terrael$releasever' --setopt='terra.gpgkey=https://repos.fyralabs.com/terrael$releasever/key.asc' terra-{release,mock-configs} subatomic-cli anda mock rpm-build mock-scm git-lfs wget less podman fuse-overlayfs sudo gh util-linux
-
-RUN dnf clean all
+RUN dnf in -y --setopt=install_weak_deps=False --repofrompath 'terra,https://repos.fyralabs.com/terrael$releasever' --setopt='terra.gpgkey=https://repos.fyralabs.com/terrael$releasever/key.asc' terra-{release,mock-configs} anda-srpm-macros subatomic-cli anda rpm-build git-lfs wget less podman fuse-overlayfs gh mold util-linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ RUN rpm -i ./*.rpm && \
     sed -Ei '/^metalink/ s/^/#/' /etc/yum.repos.d/epel.repo && \
     sed -Ei '/\[crb\]/,/^$/ s@^enabled=0$@enabled=1@' /etc/yum.repos.d/centos.repo
 
-RUN dnf in -y --setopt=install_weak_deps=False --repofrompath 'terra,https://repos.fyralabs.com/terrael$releasever' --setopt='terra.gpgkey=https://repos.fyralabs.com/terrael$releasever/key.asc' terra-{release,mock-configs} subatomic-cli anda mock rpm-build mock-scm git-lfs wget less podman fuse-overlayfs sudo gh script
+RUN dnf in -y --setopt=install_weak_deps=False --repofrompath 'terra,https://repos.fyralabs.com/terrael$releasever' --setopt='terra.gpgkey=https://repos.fyralabs.com/terrael$releasever/key.asc' terra-{release,mock-configs} subatomic-cli anda mock rpm-build mock-scm git-lfs wget less podman fuse-overlayfs sudo gh util-linux
 
 RUN dnf clean all


### PR DESCRIPTION
CentOS Stream releases development versions before Alma, but we're likely using Alma once EL10 is released. Alma has released their development EL10 version, so this changes our EL10 builder bootstrap image to use Alma's base image.