### PR TITLE
Update Dockerfile to Alma kitten image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream10-development
+FROM quay.io/almalinuxorg/almalinux:10-kitten
 
 #RUN sed -i 's@^enabled=0@enabled=1@' /etc/yum.repos.d/almalinux-crb.repo &\
 RUN curl https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm -o epel-release-latest-10.noarch.rpm &\


### PR DESCRIPTION
Second try's the charm
We're currently using CentOS stream 10 development as our base image for EL10 since it's still prerelease. Once EL10 is released, we'll likely use Alma. Alma has released their EL10 development version, so this PR will swap over to the Alma development bootstrap image. We'll need to remove the kitten part once EL10 releases.