### PR TITLE
feat: Add (disabled) subrepos

### DIFF
--- a/dnf.conf
+++ b/dnf.conf
@@ -40,6 +40,7 @@ repo_gpgcheck=1
 enabled=0
 enabled_metadata=1
 priority=80
+excludepkgs=dkms-nvidia*
 
 [terra-mesa]
 name=Terra $releasever (Mesa)
@@ -47,7 +48,17 @@ baseurl=https://repos.fyralabs.com/terra$releasever-mesa
 type=rpm
 gpgkey=https://repos.fyralabs.com/terra$releasever-mesa/key.asc
 repo_gpgcheck=1
-enabled=1
+enabled=0
+enabled_metadata=1
+priority=80
+
+[terra-multimedia]
+name=Terra $releasever (Multimedia)
+baseurl=https://repos.fyralabs.com/terra$releasever-multimedia
+type=rpm
+gpgkey=https://repos.fyralabs.com/terra$releasever-multimedia/key.asc
+repo_gpgcheck=1
+enabled=0
 enabled_metadata=1
 priority=80
 


### PR DESCRIPTION
I'm not sure why Mesa was disabled by default since that would potentially make our builds using Mesa (namely those not in Extras) conflict with Fedora but

Adds multimedia as a disabled repo. A while back Cappy and I had an idea to add the subrepos but disabled to the builder and Mock configs but some kind of anda.hcl toggle to enable them.

This is the builder part.

Reopening of #12 because I accidentally deleted it.