### PR TITLE
bootstrap anda from source to pick up util-linux 2.42 fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN \
     dnf5 in -y --nogpgcheck --repo=terra terra-gpg-keys &&\
     dnf5 up -y &&\
     dnf5 swap -y systemd-standalone-sysusers systemd &&\
-    dnf5 in -y terra-mock-configs terra-mock-gpg-keys subatomic-cli terra-appstream-helper mock-scm \
+    dnf5 in -y terra-mock-configs terra-mock-gpg-keys subatomic-cli anda-srpm-macros terra-appstream-helper mock-scm \
         gh wget less podman fuse-overlayfs dnf5-plugins dnf-plugins-core script mold sudo terra-sccache jq @buildsys-build &&\
     cargo install --git https://github.com/FyraLabs/anda --locked &&\
     dnf5 clean packages dbcache

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,5 @@ RUN \
     dnf5 swap -y systemd-standalone-sysusers systemd &&\
     dnf5 in -y terra-mock-configs terra-mock-gpg-keys subatomic-cli anda{,-srpm-macros} terra-appstream-helper mock-scm \
         gh wget less podman fuse-overlayfs dnf5-plugins dnf-plugins-core script mold sudo terra-sccache jq @buildsys-build &&\
+    cargo install --git https://github.com/FyraLabs/anda --locked &&\
     dnf5 clean packages dbcache

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN \
     dnf5 in -y --nogpgcheck --repo=terra terra-gpg-keys &&\
     dnf5 up -y &&\
     dnf5 swap -y systemd-standalone-sysusers systemd &&\
-    dnf5 in -y terra-mock-configs terra-mock-gpg-keys subatomic-cli anda{,-srpm-macros} terra-appstream-helper mock-scm \
+    dnf5 in -y terra-mock-configs terra-mock-gpg-keys subatomic-cli terra-appstream-helper mock-scm \
         gh wget less podman fuse-overlayfs dnf5-plugins dnf-plugins-core script mold sudo terra-sccache jq @buildsys-build &&\
     cargo install --git https://github.com/FyraLabs/anda --locked &&\
     dnf5 clean packages dbcache


### PR DESCRIPTION
The anda RPM in the builder image predates the `-O /dev/null` fix (FyraLabs/anda#421), so anda can't rebuild itself on rawhide; it hits `script: unexpected number of arguments` from util-linux 2.42.

This adds `cargo install --git https://github.com/FyraLabs/anda --locked` to overlay the fixed anda binary on top of the RPM-installed one, breaking the chicken-and-egg cycle.

Once the anda RPM is rebuilt with the fix, this line can be removed.

Ref: terrapkg/packages#11057