### PR TITLE
Specify anda package for cargo install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ RUN \
     dnf5 swap -y systemd-standalone-sysusers systemd &&\
     dnf5 in -y terra-mock-configs terra-mock-gpg-keys subatomic-cli anda-srpm-macros cargo terra-appstream-helper mock-scm \
         gh wget less podman fuse-overlayfs dnf5-plugins dnf-plugins-core script mold sudo terra-sccache jq @buildsys-build &&\
-    cargo install --git https://github.com/FyraLabs/anda --locked &&\
+    cargo install --git https://github.com/FyraLabs/anda anda --locked &&\
     dnf5 clean packages dbcache


### PR DESCRIPTION
The anda repo contains multiple binary packages (anda and xtask), so cargo install fails without specifying which one to build.