### PR TITLE
Add openssl-devel and cargo PATH for building anda from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.fedoraproject.org/fedora-minimal:rawhide
 
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 COPY dnf.conf /etc/dnf/dnf.conf
 
 RUN \
@@ -11,7 +13,7 @@ RUN \
     dnf5 in -y --nogpgcheck --repo=terra terra-gpg-keys &&\
     dnf5 up -y &&\
     dnf5 swap -y systemd-standalone-sysusers systemd &&\
-    dnf5 in -y terra-mock-configs terra-mock-gpg-keys subatomic-cli anda-srpm-macros cargo terra-appstream-helper mock-scm \
+    dnf5 in -y terra-mock-configs terra-mock-gpg-keys subatomic-cli anda-srpm-macros cargo openssl-devel terra-appstream-helper mock-scm \
         gh wget less podman fuse-overlayfs dnf5-plugins dnf-plugins-core script mold sudo terra-sccache jq @buildsys-build &&\
     cargo install --git https://github.com/FyraLabs/anda anda --locked &&\
     dnf5 clean packages dbcache


### PR DESCRIPTION
Adds openssl-devel (needed by openssl-sys crate) and sets PATH to include /root/.cargo/bin so cargo-installed binaries are available.