### PR TITLE
Install anda from dnf instead of building from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM registry.fedoraproject.org/fedora-minimal:rawhide
 
-ENV PATH="/root/.cargo/bin:${PATH}"
-
 COPY dnf.conf /etc/dnf/dnf.conf
 
 RUN \
@@ -13,7 +11,6 @@ RUN \
     dnf5 in -y --nogpgcheck --repo=terra terra-gpg-keys &&\
     dnf5 up -y &&\
     dnf5 swap -y systemd-standalone-sysusers systemd &&\
-    dnf5 in -y terra-mock-configs terra-mock-gpg-keys subatomic-cli anda-srpm-macros cargo openssl-devel terra-appstream-helper mock-scm \
+    dnf5 in -y terra-mock-configs terra-mock-gpg-keys subatomic-cli anda{,-srpm-macros} terra-appstream-helper mock-scm \
         gh wget less podman fuse-overlayfs dnf5-plugins dnf-plugins-core script mold sudo terra-sccache jq @buildsys-build &&\
-    cargo install --git https://github.com/FyraLabs/anda anda --locked &&\
     dnf5 clean packages dbcache


### PR DESCRIPTION
Reverts to installing anda via dnf5 instead of cargo install from git. Removes cargo, openssl-devel, and the PATH env that were only needed for the source build.