### PR TITLE
[frawhide] chore(Dockerfile): Update needed packages, split RUN steps out for better debugging logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,14 @@ FROM registry.fedoraproject.org/fedora-minimal:rawhide
 
 COPY dnf.conf /etc/dnf/dnf.conf
 
-RUN \
-    sed -i 's/.fc%{fedora}/.fcrawhide/g' /usr/lib/rpm/macros.d/macros.dist &&\
-    sed -i '/\[fedora\]\|\[updates\]/a enabled=0' /etc/dnf/dnf.conf &&\
-    sed -iE '/^metadata_expire/d' /etc/yum.repos.d/fedora-rawhide.repo &&\
-    cat /etc/yum.repos.d/fedora-rawhide.repo >> /etc/dnf/dnf.conf &&\
-    cat /etc/dnf/dnf.conf &&\
-    dnf5 in -y --nogpgcheck --repo=terra terra-gpg-keys &&\
-    dnf5 up -y &&\
-    dnf5 swap -y systemd-standalone-sysusers systemd &&\
-    dnf5 in -y terra-mock-configs terra-mock-gpg-keys subatomic-cli anda{,-srpm-macros} terra-appstream-helper mock-scm \
+RUN sed -i 's/.fc%{fedora}/.fcrawhide/g' /usr/lib/rpm/macros.d/macros.dist
+RUN sed -i '/\[fedora\]\|\[updates\]/a enabled=0' /etc/dnf/dnf.conf
+RUN sed -iE'/^metadata_expire/d' /etc/yum.repos.d/fedora-rawhide.repo
+RUN cat /etc/yum.repos.d/fedora-rawhide.repo >> /etc/dnf/dnf.conf
+RUN cat /etc/dnf/dnf.conf
+RUN dnf in -y --nogpgcheck --repo=terra terra-gpg-keys
+RUN dnf up -y
+RUN dnf swap -y systemd-standalone-sysusers systemd
+RUN dnf in -y terra-mock-configs subatomic-cli anda{,-srpm-macros} terra-appstream-helper mock-scm \
         gh wget less podman fuse-overlayfs dnf5-plugins dnf-plugins-core script mold sudo terra-sccache jq @buildsys-build &&\
-    dnf5 clean packages dbcache
+    dnf clean packages dbcache

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ RUN dnf in -y --nogpgcheck --repo=terra terra-gpg-keys
 RUN dnf up -y
 RUN dnf swap -y systemd-standalone-sysusers systemd
 RUN dnf in -y terra-mock-configs subatomic-cli anda{,-srpm-macros} terra-appstream-helper mock-scm \
-        gh wget less podman fuse-overlayfs dnf5-plugins dnf-plugins-core script mold sudo terra-sccache jq @buildsys-build &&\
-    dnf clean packages dbcache
+        gh wget less podman fuse-overlayfs dnf5-plugins dnf-plugins-core script mold sudo terra-sccache jq @buildsys-build
+RUN dnf clean packages dbcache

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ RUN dnf in -y --nogpgcheck --repo=terra terra-gpg-keys
 RUN dnf up -y
 RUN dnf swap -y systemd-standalone-sysusers systemd
 RUN dnf in -y terra-mock-configs subatomic-cli anda{,-srpm-macros} terra-appstream-helper mock-scm \
-        gh wget less podman fuse-overlayfs dnf5-plugins dnf-plugins-core script mold sudo terra-sccache jq @buildsys-build
+        gh wget less podman fuse-overlayfs dnf5-plugins util-linux-script mold sudo terra-sccache jq @buildsys-build
 RUN dnf clean packages dbcache


### PR DESCRIPTION
I also changed `dnf5` to `dnf` because DNF5 is default on all our supported Fedora versions.