### PR TITLE
fix: use prebuilt sccache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN sed -i 's/.fc%{fedora}/.fcrawhide/g' /usr/lib/rpm/macros.d/macros.dist && \
     sed -iE '/^metadata_expire/d' /etc/yum.repos.d/fedora-rawhide.repo && \
     cat /etc/yum.repos.d/fedora-rawhide.repo >> /etc/dnf/dnf.conf && \
     cat /etc/dnf/dnf.conf && \
+    curl https://github.com/mozilla/sccache/releases/download/v0.15.0/sccache-v0.15.0-$(arch)-unknown-linux-musl.tar.gz | tar x --strip-components=1 && \
+    install -Dpm755 sccache -t /usr/bin && \
     dnf in -y --nogpgcheck --repo=terra terra-gpg-keys && \
     dnf up -y && \
     dnf swap -y systemd-standalone-sysusers systemd && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN sed -i 's/.fc%{fedora}/.fcrawhide/g' /usr/lib/rpm/macros.d/macros.dist && \
     dnf swap -y systemd-standalone-sysusers systemd && \
     dnf in -y terra-mock-configs subatomic-cli anda{,-srpm-macros} terra-appstream-helper mock-scm \
         gh wget less podman fuse-overlayfs dnf5-plugins util-linux-script mold sudo jq @buildsys-build tar && \
-    curl https://github.com/mozilla/sccache/releases/download/v0.15.0/sccache-v0.15.0-$(arch)-unknown-linux-musl.tar.gz | tar x --strip-components=1 && \
+    curl -L https://github.com/mozilla/sccache/releases/download/v0.15.0/sccache-v0.15.0-$(arch)-unknown-linux-musl.tar.gz | tar x --strip-components=1 && \
     install -Dpm755 sccache -t /usr/bin && \
     dnf clean packages dbcache

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ RUN sed -i 's/.fc%{fedora}/.fcrawhide/g' /usr/lib/rpm/macros.d/macros.dist && \
     dnf up -y && \
     dnf swap -y systemd-standalone-sysusers systemd && \
     dnf in -y terra-mock-configs subatomic-cli anda{,-srpm-macros} terra-appstream-helper mock-scm \
-        gh wget less podman fuse-overlayfs dnf5-plugins util-linux-script mold sudo sccache jq @buildsys-build && \
+        gh wget less podman fuse-overlayfs dnf5-plugins util-linux-script mold sudo jq @buildsys-build && \
     dnf clean packages dbcache

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@ RUN sed -i 's/.fc%{fedora}/.fcrawhide/g' /usr/lib/rpm/macros.d/macros.dist && \
     sed -iE '/^metadata_expire/d' /etc/yum.repos.d/fedora-rawhide.repo && \
     cat /etc/yum.repos.d/fedora-rawhide.repo >> /etc/dnf/dnf.conf && \
     cat /etc/dnf/dnf.conf && \
-    curl https://github.com/mozilla/sccache/releases/download/v0.15.0/sccache-v0.15.0-$(arch)-unknown-linux-musl.tar.gz | tar x --strip-components=1 && \
-    install -Dpm755 sccache -t /usr/bin && \
     dnf in -y --nogpgcheck --repo=terra terra-gpg-keys && \
     dnf up -y && \
     dnf swap -y systemd-standalone-sysusers systemd && \
     dnf in -y terra-mock-configs subatomic-cli anda{,-srpm-macros} terra-appstream-helper mock-scm \
-        gh wget less podman fuse-overlayfs dnf5-plugins util-linux-script mold sudo jq @buildsys-build && \
+        gh wget less podman fuse-overlayfs dnf5-plugins util-linux-script mold sudo jq @buildsys-build tar && \
+    curl https://github.com/mozilla/sccache/releases/download/v0.15.0/sccache-v0.15.0-$(arch)-unknown-linux-musl.tar.gz | tar x --strip-components=1 && \
+    install -Dpm755 sccache -t /usr/bin && \
     dnf clean packages dbcache

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ RUN sed -i 's/.fc%{fedora}/.fcrawhide/g' /usr/lib/rpm/macros.d/macros.dist && \
     dnf up -y && \
     dnf swap -y systemd-standalone-sysusers systemd && \
     dnf in -y terra-mock-configs subatomic-cli anda{,-srpm-macros} terra-appstream-helper mock-scm \
-        gh wget less podman fuse-overlayfs dnf5-plugins util-linux-script mold sudo terra-sccache jq @buildsys-build && \
+        gh wget less podman fuse-overlayfs dnf5-plugins util-linux-script mold sudo sccache jq @buildsys-build && \
     dnf clean packages dbcache

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN sed -i 's/.fc%{fedora}/.fcrawhide/g' /usr/lib/rpm/macros.d/macros.dist && \
     dnf swap -y systemd-standalone-sysusers systemd && \
     dnf in -y terra-mock-configs subatomic-cli anda{,-srpm-macros} terra-appstream-helper mock-scm \
         gh wget less podman fuse-overlayfs dnf5-plugins util-linux-script mold sudo jq @buildsys-build tar && \
-    curl -L https://github.com/mozilla/sccache/releases/download/v0.15.0/sccache-v0.15.0-$(arch)-unknown-linux-musl.tar.gz | tar x --strip-components=1 && \
+    curl -L https://github.com/mozilla/sccache/releases/download/v0.15.0/sccache-v0.15.0-$(arch)-unknown-linux-musl.tar.gz | tar xz --strip-components=1 && \
     install -Dpm755 sccache -t /usr/bin && \
     dnf clean packages dbcache


### PR DESCRIPTION
we cannot create the builder because terra-sccache cannot be built when the builder doesn't exist. This removes the need to build terra-sccache during the bootstrap process